### PR TITLE
Fix cards being removed at initial transition end

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,31 +1,35 @@
 {
-  "name": "brown-briefcase",
-  "private": true,
-  "version": "0.0.0",
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
-    "lint": "eslint .",
-    "preview": "vite preview"
-  },
-  "dependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "uuid": "^11.1.0"
-  },
-  "devDependencies": {
-    "@eslint/js": "^9.21.0",
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
-    "@vitejs/plugin-react-swc": "^3.8.0",
-    "eslint": "^9.21.0",
-    "eslint-plugin-react-hooks": "^5.1.0",
-    "eslint-plugin-react-refresh": "^0.4.19",
-    "globals": "^15.15.0",
-    "sass": "^1.86.0",
-    "typescript": "~5.7.2",
-    "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0"
-  }
+	"name": "brown-briefcase",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"scripts": {
+		"dev": "vite",
+		"build": "tsc -b && vite build",
+		"lint": "eslint .",
+		"preview": "vite preview"
+	},
+	"dependencies": {
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
+		"uuid": "^11.1.0"
+	},
+	"devDependencies": {
+		"@eslint/js": "^9.21.0",
+		"@types/react": "^19.0.10",
+		"@types/react-dom": "^19.0.4",
+		"@vitejs/plugin-react-swc": "^3.8.0",
+		"eslint": "^9.21.0",
+		"eslint-plugin-react-hooks": "^5.1.0",
+		"eslint-plugin-react-refresh": "^0.4.19",
+		"globals": "^15.15.0",
+		"sass": "^1.86.0",
+		"typescript": "~5.7.2",
+		"typescript-eslint": "^8.24.1",
+		"vite": "^6.2.0"
+	},
+	"prettier": {
+		"printWidth": 80,
+		"useTabs": true
+	}
 }

--- a/src/components/TodoCard/TodoCard.tsx
+++ b/src/components/TodoCard/TodoCard.tsx
@@ -37,7 +37,8 @@ export const TodoCard = ({ todo, onRemove }: TodoCardProps) => {
 	};
 
 	const handleTransitionEnd = (): void => {
-		onRemove(todo.id);
+		if (!cardRef.current?.classList.contains("todo-card--visible"))
+			onRemove(todo.id);
 	};
 
 	const formattedDate = new Intl.DateTimeFormat("sv-SE", {


### PR DESCRIPTION
This request will fix the bug causing the cards to be removed prematurely by checking if the card to be removed contains the `--visible` attribute class.

This pull request also adds a prettier config to the `package.json` file using a guestimation of the original authors tab and line settings.
The reason being that my settings ruined the formatting of the original author upon saving.